### PR TITLE
Fix Linux 64bit GCC compilation, adjust Makefile

### DIFF
--- a/crnlib/Makefile
+++ b/crnlib/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS = -O3 -fomit-frame-pointer -ffast-math -fno-math-errno -g -fno-strict-aliasing -Wall -Wno-unused-value -Wno-unused -march=core2
+CXXFLAGS = -O3 -fomit-frame-pointer -ffast-math -fno-math-errno -g -fno-strict-aliasing -Wall -Wno-unused-value -Wno-unused -march=native
 LDFLAGS = -lpthread -g
 
 OBJECTS = \

--- a/crnlib/Makefile
+++ b/crnlib/Makefile
@@ -1,5 +1,5 @@
-COMPILE_OPTIONS = -O3 -fomit-frame-pointer -ffast-math -fno-math-errno -g -fno-strict-aliasing -Wall -Wno-unused-value -Wno-unused -march=core2
-LINKER_OPTIONS = -lpthread -g
+CXXFLAGS = -O3 -fomit-frame-pointer -ffast-math -fno-math-errno -g -fno-strict-aliasing -Wall -Wno-unused-value -Wno-unused -march=core2
+LDFLAGS = -lpthread -g
 
 OBJECTS = \
   crn_arealist.o \
@@ -77,20 +77,24 @@ OBJECTS = \
   lzma_LzmaEnc.o \
   lzma_LzmaLib.o
 
+.PHONY: clean all
+
 all: crunch
 
 %.o: %.cpp
-	g++ $< -o $@ -c $(COMPILE_OPTIONS)
+	$(CXX) $< -o $@ -c $(CXXFLAGS)
 
 crunch.o: ../crunch/crunch.cpp
-	g++ $< -o $@ -c -I../inc -I../crnlib $(COMPILE_OPTIONS)
+	$(CXX) $< -o $@ -c -I../inc -I../crnlib $(CXXFLAGS)
 
 corpus_gen.o: ../crunch/corpus_gen.cpp
-	g++ $< -o $@ -c -I../inc -I../crnlib $(COMPILE_OPTIONS)
+	$(CXX) $< -o $@ -c -I../inc -I../crnlib $(CXXFLAGS)
 
 corpus_test.o: ../crunch/corpus_test.cpp
-	g++ $< -o $@ -c -I../inc -I../crnlib $(COMPILE_OPTIONS)
+	$(CXX) $< -o $@ -c -I../inc -I../crnlib $(CXXFLAGS)
 
 crunch: $(OBJECTS) crunch.o corpus_gen.o corpus_test.o
-	g++ $(OBJECTS) crunch.o corpus_gen.o corpus_test.o -o crunch $(LINKER_OPTIONS)
+	$(CXX) $(OBJECTS) crunch.o corpus_gen.o corpus_test.o -o crunch $(LDFLAGS)
 
+clean:
+	$(RM) $(OBJECTS) crunch

--- a/crnlib/crn_math.h
+++ b/crnlib/crn_math.h
@@ -56,8 +56,7 @@ namespace crnlib
 
       template<typename T> inline T square(T value) { return value * value; }
 
-      inline bool is_power_of_2(uint32 x) { return x && ((x & (x - 1U)) == 0U); }
-      inline bool is_power_of_2(uint64 x) { return x && ((x & (x - 1U)) == 0U); }
+      template<typename T> inline bool is_power_of_2(T x) { return x && ((x & (x - 1U)) == 0U); }
 
       template<typename T> inline T align_up_value(T x, uint alignment)
       {

--- a/crnlib/crn_sparse_array.h
+++ b/crnlib/crn_sparse_array.h
@@ -355,7 +355,7 @@ namespace crnlib
 
       inline T* alloc_group(bool nofail = false)
       {
-         T* p = static_cast<T*>(alloc_space(N * sizeof(T)));
+         T* p = static_cast<T*>(this->alloc_space(N * sizeof(T)));
 
          if (!p)
          {
@@ -365,7 +365,7 @@ namespace crnlib
             CRNLIB_FAIL("Out of memory");
          }
 
-         construct_group(p);
+         this->construct_group(p);
 
          m_num_active_groups++;
 
@@ -379,20 +379,20 @@ namespace crnlib
             CRNLIB_ASSERT(m_num_active_groups);
             m_num_active_groups--;
 
-            destruct_group(p);
+            this->destruct_group(p);
 
-            free_space(p);
+            this->free_space(p);
          }
       }
 
       inline void init_default()
       {
-         construct_element(reinterpret_cast<T*>(m_default));
+         this->construct_element(reinterpret_cast<T*>(m_default));
       }
 
       inline void deinit_default()
       {
-         destruct_element(reinterpret_cast<T*>(m_default));
+         this->destruct_element(reinterpret_cast<T*>(m_default));
       }
    };
 

--- a/crnlib/crn_vector.cpp
+++ b/crnlib/crn_vector.cpp
@@ -23,7 +23,7 @@ namespace crnlib
 
       size_t new_capacity = min_new_capacity;
       if ((grow_hint) && (!math::is_power_of_2(new_capacity)))
-         new_capacity = math::next_pow2(new_capacity);
+         new_capacity = math::next_pow2((uint32)new_capacity);
 
       CRNLIB_ASSERT(new_capacity && (new_capacity > m_capacity));
 

--- a/inc/crn_decomp.h
+++ b/inc/crn_decomp.h
@@ -374,7 +374,7 @@ namespace crnd
 
    const uint32 cIntBits = 32U;
 
-#ifdef _WIN64
+#if defined(_WIN64) || defined(__LP64__)
    typedef uint64 ptr_bits;
 #else
    typedef uint32 ptr_bits;


### PR DESCRIPTION
There are still lots of warnings, mostly related to dangerous casts, but it compiles and is able to show the help output with GCC 5.2.0.
## Makefile
- `COMPILER_OPTIONS` was replaced with the standard convention of `CXXFLAGS` for C++ files.
- `LINKER_OPTIONS` was replaced with the standard convention of `LDFLAGS`.
- `g++` was replaced with `$(CXX)`, which by default is `g++` for GNU Make.
- `all` was made a phony target due to not creating an output named "all".
- A phony target `clean` was added, which calls `$(RM)` (equivalent to `rm -f` in GNU Make by default) on the output files.
- Replaced `-march=core2` with `-march=native`. Closes issue #13.
## Code
- Fix a number of compilation errors by turning calls to members in some places to dependant(?) calls by prefixing `this->`.
- Turn `is_power_of_2` into a template to solve ambiguity errors related to calling it with `size_t`.
- Explicitly cast a `size_t` to `uint32` in one place to resolve an ambiguity error. Might be incorrect, but I'm not knowledgeable enough with C++ to propose a cleaner fix.
- Systems other than Windows can have 64 bits too.

All in all, most likely closes issue #10.
